### PR TITLE
stop using _get_shared_lib_location for init

### DIFF
--- a/python/polars_talib/__init__.py
+++ b/python/polars_talib/__init__.py
@@ -1,14 +1,14 @@
 import atexit
+from pathlib import Path
 import polars as pl
 from polars.type_aliases import IntoExpr
-from polars.utils.udfs import _get_shared_lib_location
 from ._polars_talib import initialize, shutdown, version
 
 
 __talib_version__ = version()
 
 # Boilerplate needed to inform Polars of the location of binary wheel.
-lib = _get_shared_lib_location(__file__)
+lib = Path(__file__).parent
 initialize()
 atexit.register(shutdown)
 


### PR DESCRIPTION
This PR is to enable compatibility with polars >= 1.0.0

For now, this includes only the fix for now using `_get_shared_lib_location` when initializing the extension.

Progress:

- [X] ~~stop using _get_shared_lib_location~~
- [ ] (https://github.com/Yvictor/polars_ta_extension/issues/4) DeprecationWarning: register_plugin is deprecated. Use polars.plugins.register_plugin_function instead

I'd appreciate some help with the second task, as I'm not very familiar with the extension registration part of polars.