### PR TITLE
fix: correct calculation error when series type is f32

### DIFF
--- a/src/overlap.rs
+++ b/src/overlap.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_series_f64_ptr, ta_code2err};
+use crate::utils::{cast_series_to_f64, get_series_f64_ptr, ta_code2err};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use talib::common::TimePeriodKwargs;
@@ -18,7 +18,7 @@ pub fn bbands_output(_: &[Field]) -> PolarsResult<Field> {
 
 #[polars_expr(output_type_func=bbands_output)]
 fn bbands(inputs: &[Series], kwargs: BBANDSKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_bbands(input_ptr, len, &kwargs);
@@ -36,7 +36,7 @@ fn bbands(inputs: &[Series], kwargs: BBANDSKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn ema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     // println!("has_validity: {}", input.has_validity());
@@ -51,7 +51,7 @@ fn ema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn dema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_dema(input_ptr, len, &kwargs);
@@ -63,7 +63,7 @@ fn dema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn ht_trendline(inputs: &[Series]) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_ht_trendline(input_ptr, len);
@@ -75,7 +75,7 @@ fn ht_trendline(inputs: &[Series]) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn kama(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_kama(input_ptr, len, &kwargs);
@@ -87,7 +87,7 @@ fn kama(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn ma(inputs: &[Series], kwargs: MaKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_ma(input_ptr, len, &kwargs);
@@ -106,7 +106,7 @@ pub fn mama_output(_: &[Field]) -> PolarsResult<Field> {
 
 #[polars_expr(output_type_func=mama_output)]
 fn mama(inputs: &[Series], kwargs: MamaKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_mama(input_ptr, len, &kwargs);
@@ -123,8 +123,8 @@ fn mama(inputs: &[Series], kwargs: MamaKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn mavp(inputs: &[Series], kwargs: MavpKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
-    let in_time_period = &mut inputs[1].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
+    let in_time_period = &mut cast_series_to_f64(&inputs[1]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let (in_time_period_ptr, _in_time_period) = get_series_f64_ptr(in_time_period)?;
     let len = input.len();
@@ -137,7 +137,7 @@ fn mavp(inputs: &[Series], kwargs: MavpKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn midpoint(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (input_ptr, _input) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_midpoint(input_ptr, len, &kwargs);
@@ -149,8 +149,8 @@ fn midpoint(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series>
 
 #[polars_expr(output_type=Float64)]
 fn midprice(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let high = &mut inputs[0].to_float()?.rechunk();
-    let low = &mut inputs[1].to_float()?.rechunk();
+    let high = &mut cast_series_to_f64(&inputs[0]);
+    let low = &mut cast_series_to_f64(&inputs[1]);
     let (high_ptr, _high) = get_series_f64_ptr(high)?;
     let (low_ptr, _low) = get_series_f64_ptr(low)?;
     let len = high.len();
@@ -163,8 +163,8 @@ fn midprice(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series>
 
 #[polars_expr(output_type=Float64)]
 fn sar(inputs: &[Series], kwargs: SarKwargs) -> PolarsResult<Series> {
-    let high = &mut inputs[0].to_float()?.rechunk();
-    let low = &mut inputs[1].to_float()?.rechunk();
+    let high = &mut cast_series_to_f64(&inputs[0]);
+    let low = &mut cast_series_to_f64(&inputs[1]);
     let (high_ptr, _high) = get_series_f64_ptr(high)?;
     let (low_ptr, _low) = get_series_f64_ptr(low)?;
     let len = high.len();
@@ -177,8 +177,8 @@ fn sar(inputs: &[Series], kwargs: SarKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn sarext(inputs: &[Series], kwargs: SarExtKwargs) -> PolarsResult<Series> {
-    let high = &mut inputs[0].to_float()?.rechunk();
-    let low = &mut inputs[1].to_float()?.rechunk();
+    let high = &mut cast_series_to_f64(&inputs[0]);
+    let low = &mut cast_series_to_f64(&inputs[1]);
     let (high_ptr, _high) = get_series_f64_ptr(high)?;
     let (low_ptr, _low) = get_series_f64_ptr(low)?;
     let len = high.len();
@@ -191,7 +191,7 @@ fn sarext(inputs: &[Series], kwargs: SarExtKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn sma(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (in_real_ptr, _in_real) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_sma(in_real_ptr, len, &kwargs);
@@ -203,7 +203,7 @@ fn sma(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn t3(inputs: &[Series], kwargs: T3Kwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (in_real_ptr, _in_real) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_t3(in_real_ptr, len, &kwargs);
@@ -215,7 +215,7 @@ fn t3(inputs: &[Series], kwargs: T3Kwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn tema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (in_real_ptr, _in_real) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_tema(in_real_ptr, len, &kwargs);
@@ -227,7 +227,7 @@ fn tema(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn trima(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (in_real_ptr, _in_real) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_trima(in_real_ptr, len, &kwargs);
@@ -239,7 +239,7 @@ fn trima(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=Float64)]
 fn wma(inputs: &[Series], kwargs: TimePeriodKwargs) -> PolarsResult<Series> {
-    let input = &mut inputs[0].to_float()?.rechunk();
+    let input = &mut cast_series_to_f64(&inputs[0]);
     let (in_real_ptr, _in_real) = get_series_f64_ptr(input)?;
     let len = input.len();
     let res = ta_wma(in_real_ptr, len, &kwargs);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,15 @@
+use polars::datatypes::DataType;
 use polars::prelude::{Float64Chunked, IntoSeries, PolarsError, PolarsResult, Series};
 use talib_sys::TA_RetCode;
+
+pub fn cast_series_to_f64(series: &Series) -> Series {
+    match series.dtype() {
+        DataType::Float64 => Ok(series.clone()),
+        _ => series.cast(&DataType::Float64),
+    }
+    .unwrap()
+    .rechunk()
+}
 
 pub fn get_series_f64_ptr(series: &mut Series) -> PolarsResult<(*const f64, Option<Series>)> {
     if series.has_validity() {


### PR DESCRIPTION
## Problem Cause
The Talib function expects input of type double. When the input Series has a data type of f32, it leads to abnormal calculation results. Initially, the `to_float` function of Polars was used for type conversion, but this function does not handle the conversion from f32 to f64 since f32 is already a floating-point type. Passing the chunk pointer of type f32 directly as double to the Talib calculation results in memory alignment issues, affecting the calculation results. As encountered in issue #11, the attached image shows that fields like `adjusted_close` are of type f32.
![image](https://github.com/user-attachments/assets/9d24f028-bbda-4261-abc1-df09c0d5fcb7)

## Changes Made
1. Added the `cast_series_to_f64` function to `utils.rs`, which casts non-f64 types and rechunks.
2. Replaced the usage of `to_float` with `cast_series_to_f64` in `overlap.rs` to convert non-f64 Series types, ensuring all input data for Talib functions are of type double.

https://github.com/Yvictor/polars_ta_extension/blob/dcfd75ac2191c3718ca91189fd80eb7a73b5abf3/src/overlap.rs#L21

```rust
let input = &mut cast_series_to_f64(&inputs[0]);
```
```rust
pub fn cast_series_to_f64(series: &Series) -> Series {
    match series.dtype() {
        DataType::Float64 => Ok(series.clone()),
        _ => series.cast(&DataType::Float64),
    }
    .unwrap()
    .rechunk()
}
```