### PR TITLE
Fix TA-Lib outputs for short grouped windows

### DIFF
--- a/talib/src/math.rs
+++ b/talib/src/math.rs
@@ -1,5 +1,8 @@
-use crate::utils::{check_begin_idx2, check_begin_idx1};
-use crate::{common::TimePeriodKwargs, utils::make_vec};
+use crate::utils::{check_begin_idx1, check_begin_idx2};
+use crate::{
+    common::TimePeriodKwargs,
+    utils::{cannot_produce_output, make_default_vec, make_vec},
+};
 
 use talib_sys::{TA_ACOS_Lookback, TA_ACOS};
 use talib_sys::{TA_ADD_Lookback, TA_Integer, TA_RetCode, TA_ADD};
@@ -118,6 +121,12 @@ pub fn ta_max(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MAX_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok(make_default_vec(len));
+    }
     let (mut out, ptr) = make_vec(len, lookback);
     let ret_code = unsafe {
         TA_MAX(
@@ -158,6 +167,12 @@ pub fn ta_maxindex(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MAXINDEX_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok(make_default_vec(len));
+    }
     let (mut out, ptr) = make_vec(len, lookback);
     let ret_code = unsafe {
         TA_MAXINDEX(
@@ -198,6 +213,12 @@ pub fn ta_min(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MIN_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok(make_default_vec(len));
+    }
     let (mut out, ptr) = make_vec(len, lookback);
     let ret_code = unsafe {
         TA_MIN(
@@ -238,6 +259,12 @@ pub fn ta_minindex(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MININDEX_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok(make_default_vec(len));
+    }
     let (mut out, ptr) = make_vec(len, lookback);
     let ret_code = unsafe {
         TA_MININDEX(
@@ -278,6 +305,12 @@ pub fn ta_minmax(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MINMAX_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok((make_default_vec(len), make_default_vec(len)));
+    }
     let (mut out_min, ptr_min) = make_vec(len, lookback);
     let (mut out_max, ptr_max) = make_vec(len, lookback);
     let ret_code = unsafe {
@@ -326,6 +359,12 @@ pub fn ta_minmaxindex(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MINMAXINDEX_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok((make_default_vec(len), make_default_vec(len)));
+    }
     let (mut out_min, ptr_min) = make_vec(len, lookback);
     let (mut out_max, ptr_max) = make_vec(len, lookback);
     let ret_code = unsafe {
@@ -446,6 +485,12 @@ pub fn ta_sum(
     let begin_idx = check_begin_idx1(len, real_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_SUM_Lookback(kwargs.timeperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok(make_default_vec(len));
+    }
     let (mut out, ptr) = make_vec(len, lookback);
     let ret_code = unsafe {
         TA_SUM(

--- a/talib/src/momentum.rs
+++ b/talib/src/momentum.rs
@@ -1,5 +1,8 @@
 use crate::utils::{check_begin_idx1, check_begin_idx2, check_begin_idx3, check_begin_idx4};
-use crate::{common::TimePeriodKwargs, utils::make_vec};
+use crate::{
+    common::TimePeriodKwargs,
+    utils::{cannot_produce_output, make_default_vec, make_vec},
+};
 use derive_builder::Builder;
 use serde::Deserialize;
 use talib_sys::{TA_ADXR_Lookback, TA_ADXR};
@@ -452,6 +455,16 @@ pub fn ta_macd(
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx
         + unsafe { TA_MACD_Lookback(kwargs.fastperiod, kwargs.slowperiod, kwargs.signalperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok((
+            make_default_vec(len),
+            make_default_vec(len),
+            make_default_vec(len),
+        ));
+    }
     let (mut outmacd, ptr1) = make_vec(len, lookback);
     let (mut outmacdsignal, ptr2) = make_vec(len, lookback);
     let (mut outmacdhist, ptr3) = make_vec(len, lookback);
@@ -519,6 +532,16 @@ pub fn ta_macdext(
                 kwargs.signalmatype,
             )
         };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok((
+            make_default_vec(len),
+            make_default_vec(len),
+            make_default_vec(len),
+        ));
+    }
     let (mut outmacd, ptr1) = make_vec(len, lookback);
     let (mut outmacdsignal, ptr2) = make_vec(len, lookback);
     let (mut outmacdhist, ptr3) = make_vec(len, lookback);
@@ -571,6 +594,16 @@ pub fn ta_macdfix(
     let begin_idx = check_begin_idx1(len, input_ptr) as i32;
     let end_idx = len as i32 - begin_idx - 1;
     let lookback = begin_idx + unsafe { TA_MACDFIX_Lookback(kwargs.signalperiod) };
+    if lookback < 0 {
+        return Err(TA_RetCode::TA_BAD_PARAM);
+    }
+    if cannot_produce_output(len, lookback) {
+        return Ok((
+            make_default_vec(len),
+            make_default_vec(len),
+            make_default_vec(len),
+        ));
+    }
     let (mut outmacd, ptr1) = make_vec(len, lookback);
     let (mut outmacdsignal, ptr2) = make_vec(len, lookback);
     let (mut outmacdhist, ptr3) = make_vec(len, lookback);

--- a/talib/src/utils.rs
+++ b/talib/src/utils.rs
@@ -26,6 +26,17 @@ where
     (vec, ptr)
 }
 
+pub fn make_default_vec<T>(len: usize) -> Vec<T>
+where
+    T: Copy + CustomDefault,
+{
+    vec![T::default(); len]
+}
+
+pub fn cannot_produce_output(len: usize, lookback: i32) -> bool {
+    lookback >= 0 && (lookback as usize) >= len
+}
+
 pub fn check_begin_idx1(len: usize, arr_ptr: *const f64) -> usize {
     let mut begin_idx = 0;
     for i in 0..len {

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,96 @@
+import numpy as np
+import polars as pl
+import polars_talib as plta
+import pytest
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        plta.max(pl.col("c"), 2),
+        plta.min(pl.col("c"), 2),
+        plta.sum(pl.col("c"), 2),
+    ],
+)
+def test_float_math_over_short_null_and_nan_groups_preserves_length(expr: pl.Expr):
+    df = pl.DataFrame({"c": [1, 2, 3, 4, 5.0, None, np.nan]}, strict=False)
+
+    result = df.select(expr.over("c").alias("out"))
+
+    assert result.height == df.height
+    assert result["out"].is_nan().all()
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        plta.maxindex(pl.col("c"), 2),
+        plta.minindex(pl.col("c"), 2),
+    ],
+)
+def test_index_math_over_short_null_and_nan_groups_preserves_length(expr: pl.Expr):
+    df = pl.DataFrame({"c": [1, 2, 3, 4, 5.0, None, np.nan]}, strict=False)
+
+    result = df.select(expr.over("c").alias("out"))
+
+    assert result.height == df.height
+    assert result["out"].to_list() == [0] * df.height
+
+
+def test_minmax_over_short_null_and_nan_groups_preserves_length():
+    df = pl.DataFrame({"c": [1, 2, 3, 4, 5.0, None, np.nan]}, strict=False)
+
+    result = df.select(plta.minmax(pl.col("c"), 2).over("c").alias("out")).unnest("out")
+
+    assert result.height == df.height
+    assert result.select(pl.all().is_nan().all()).row(0) == (True, True)
+
+
+def test_minmaxindex_over_short_null_and_nan_groups_preserves_length():
+    df = pl.DataFrame({"c": [1, 2, 3, 4, 5.0, None, np.nan]}, strict=False)
+
+    result = df.select(plta.minmaxindex(pl.col("c"), 2).over("c").alias("out")).unnest("out")
+
+    assert result.height == df.height
+    assert result.rows() == [(0, 0)] * df.height
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        plta.max(pl.col("c"), 0),
+        plta.maxindex(pl.col("c"), 0),
+        plta.min(pl.col("c"), 0),
+        plta.minindex(pl.col("c"), 0),
+        plta.minmax(pl.col("c"), 0),
+        plta.minmaxindex(pl.col("c"), 0),
+        plta.sum(pl.col("c"), 0),
+    ],
+)
+def test_invalid_timeperiod_still_raises_bad_param(expr: pl.Expr):
+    df = pl.DataFrame({"c": [1.0, 2.0, 3.0]})
+
+    with pytest.raises(pl.exceptions.ComputeError, match="TA_BAD_PARAM"):
+        df.select(expr.alias("out"))
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        plta.macd(pl.col("close")),
+        plta.macdext(pl.col("close")),
+        plta.macdfix(pl.col("close")),
+    ],
+)
+def test_macd_over_groups_shorter_than_lookback_preserves_length(expr: pl.Expr):
+    df = pl.DataFrame(
+        {
+            "g": ["a", "a", "b", "b", "b"],
+            "close": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+
+    result = df.select(expr.over("g").alias("macd")).unnest("macd")
+
+    assert result.height == df.height
+    assert result.select(pl.all().is_nan().all()).row(0) == (True, True, True)


### PR DESCRIPTION
## Summary
- return length-matched default output when min groups cannot produce TA-Lib values
- preserve all MACD struct field lengths for groups shorter than lookback
- add Polars .over(...) regressions for null/NaN min groups and short MACD groups

Fixes #29.
Fixes #31.

## Tests
- cargo test
- uv run --python 3.11 --no-dev --with pytest --with numpy pytest tests/test_regressions.py