### PR TITLE
chore: prepare 0.1.6 release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -200,10 +200,14 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        target: [x86_64, aarch64-apple-darwin]
+        include:
+          - target: x86_64
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -229,12 +233,16 @@ jobs:
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist
+      - name: Test wheel installation
+        run: |
+          pip install dist/*.whl
+          python -c "import polars_talib; print('Import successful')"
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux, macos, windows]
+    needs: [linux, linux-arm, macos, windows]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_talib"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polars-talib"
-version = "0.1.5"
+version = "0.1.6"
 description = "Polars extension for Ta-Lib: Support Ta-Lib functions in Polars expressions"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -670,7 +670,7 @@ wheels = [
 
 [[package]]
 name = "polars-talib"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "polars", version = "0.18.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },


### PR DESCRIPTION
## Summary
- bump package metadata from 0.1.5 to 0.1.6
- make the tag release job wait for linux-arm artifacts before uploading to PyPI
- run the macOS x86_64 wheel build on the explicit Intel runner and add a native import smoke test, carrying forward the low-risk part of #25

## Validation
- cargo test
- cargo metadata --no-deps --format-version 1
- git diff --check
- workflow YAML parse check

Note: this does not publish to PyPI or push the 0.1.6 tag. After this lands and CI is green, pushing tag 0.1.6 will trigger the release upload.