### PR TITLE
ci: update actions for Node 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,12 +30,12 @@ jobs:
         #, aarch64-unknown-linux-gnu]
         #, aarch64, armv7]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Install talib
         run: |
           wget https://github.com/Yvictor/polars_ta_extension/releases/download/0.1.0/ta-lib-0.4.0-src.tar.gz
@@ -111,7 +111,7 @@ jobs:
           TA_INCLUDE_PATH: ${{ github.workspace }}/dependencies/include
           TA_LIBRARY_PATH: ${{ github.workspace }}/dependencies/lib
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}
           path: dist
@@ -123,12 +123,12 @@ jobs:
         target: [aarch64]
         # armv7l]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: install tools
         run: |
           uv tool install maturin
@@ -153,7 +153,7 @@ jobs:
           TA_INCLUDE_PATH: ${{ github.workspace }}/dependencies/include
           TA_LIBRARY_PATH: ${{ github.workspace }}/dependencies/lib
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-arm-${{ matrix.target }}
           path: dist
@@ -165,8 +165,8 @@ jobs:
       matrix:
         target: [x64, x86]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
           architecture: ${{ matrix.target }}
@@ -179,7 +179,7 @@ jobs:
         with:
           arch: ${{ matrix.target }}
       - name: install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: install tools
         run: |
           uv tool install maturin
@@ -194,7 +194,7 @@ jobs:
           TA_INCLUDE_PATH: ${{ github.workspace }}\dependencies\include
           TA_LIBRARY_PATH: ${{ github.workspace }}\dependencies\lib
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.target }}
           path: dist
@@ -209,12 +209,12 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: install tools
         run: |
           uv tool install maturin
@@ -229,7 +229,7 @@ jobs:
           TA_INCLUDE_PATH: ${{ github.workspace }}/dependencies/include
           TA_LIBRARY_PATH: ${{ github.workspace }}/dependencies/lib
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist
@@ -244,7 +244,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, linux-arm, macos, windows]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: wheels-*
           merge-multiple: true


### PR DESCRIPTION
## Summary
- update first-party GitHub actions to Node 24 compatible majors
- update setup-uv to the current major used for Node 24 compatible workflows
- keep the existing wheel matrix and release artifact behavior unchanged

## Validation
- workflow YAML parse check
- git diff --check

This addresses the Node.js 20 deprecation warning before GitHub starts forcing JavaScript actions to Node 24 by default.